### PR TITLE
[Vue warn]: Invalid prop: custom validator check failed for prop "color".

### DIFF
--- a/src/components/interface.js
+++ b/src/components/interface.js
@@ -7,7 +7,11 @@ const colorConfig = (defaultColor = "transparent") => ({
       return true;
     }
     if (typeof value === "object" && value.colors) {
-      return value.colors.every((config) => config.hasOwnProperty('color') && config.hasOwnProperty('offset'));
+      return value.colors.every((config) => {
+        let hasColor = Object.prototype.hasOwnProperty.call(config, "color");
+        let hasOffset = Object.prototype.hasOwnProperty.call(config, "offset");
+        return hasColor && hasOffset
+      });
     }
     return false;
   },

--- a/src/components/interface.js
+++ b/src/components/interface.js
@@ -7,7 +7,7 @@ const colorConfig = (defaultColor = "transparent") => ({
       return true;
     }
     if (typeof value === "object" && value.colors) {
-      return value.colors.every((config) => config.color && config.offset);
+      return value.colors.every((config) => config.hasOwnProperty('color') && config.hasOwnProperty('offset'));
     }
     return false;
   },


### PR DESCRIPTION
Because it's evaluating 0 as false, so use hasOwnProperty instead

Currently I've set offsets that start at 0 to be 0.1 to get around it

error:
[Vue warn]: Invalid prop: custom validator check failed for prop "color".