### PR TITLE
Fix legendHeight setter in mount

### DIFF
--- a/src/components/VueEllipseProgress.vue
+++ b/src/components/VueEllipseProgress.vue
@@ -53,9 +53,7 @@ export default {
   }),
   watch: {
     hideLegend() {
-      this.$nextTick(() => {
-        this.legendHeight = this.hideLegend ? 0 : this.$refs.legend.clientHeight;
-      });
+      this.updateLegendHeight();
     },
   },
   computed: {
@@ -111,10 +109,15 @@ export default {
       return normalizedCircles;
     },
   },
+  methods: {
+    updateLegendHeight() {
+      this.$nextTick(() => {
+        this.legendHeight = this.hideLegend ? 0 : this.$refs.legend?.clientHeight ?? 0;
+      });
+    },
+  },
   mounted() {
-    this.$nextTick(() => {
-      this.legendHeight = this.hideLegend ? 0 : this.$refs.legend.clientHeight;
-    });
+    this.updateLegendHeight();
   },
 };
 </script>

--- a/src/components/VueEllipseProgress.vue
+++ b/src/components/VueEllipseProgress.vue
@@ -113,7 +113,7 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      this.legendHeight = this.$refs.legend.offsetHeight;
+      this.legendHeight = this.hideLegend ? 0 : this.$refs.legend.clientHeight;
     });
   },
 };


### PR DESCRIPTION
When VueEllipseProgress mounts, it might have `legend` disabled, in which case
the `legendHeight` property should be set to `0` rather than trying to access
the nonexistent `legend` template ref.

# Thanks for your contribution!

By contributing to this project you agree to the [contribution rules](https://github.com/setaman/vue-ellipse-progress/blob/master/CONTRIBUTING.md).

Quick checklist for code changes:
- [ ] Created a new branch based on `dev`
- [ ] All test and checks passed
- [ ] No linting errors
- [ ] New tests added (if necessary)
- [ ] Docs updated (if necessary)
----

you can delete the above text, after all checks have passed 

----
